### PR TITLE
Remove old display item and add scoreboard tags

### DIFF
--- a/src/com/kicasmads/cs/data/Shop.java
+++ b/src/com/kicasmads/cs/data/Shop.java
@@ -6,6 +6,7 @@ import com.kicasmads.cs.event.ShopTransactionEvent;
 
 import net.minecraft.server.v1_16_R3.NBTTagCompound;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.block.Chest;
@@ -58,6 +59,7 @@ public class Shop {
 
         buyItem    = Utils.itemStackFromNBT(tag.getCompound("buyItem"));
         sellItem   = Utils.itemStackFromNBT(tag.getCompound("sellItem"));
+
         buyAmount  = tag.getInt("buyAmount");
         sellAmount = tag.getInt("sellAmount");
 
@@ -67,11 +69,16 @@ public class Shop {
         }else{
             display = new ShopDisplay(chest, this);
         }
-
-        if (tag.hasKey("buyDisplayItem"))
-            buyItemEntity = UUID.fromString(tag.getString("buyDisplayItem"));
-        if (tag.hasKey("sellDisplayItem"))
-            sellItemEntity = UUID.fromString(tag.getString("sellDisplayItem"));
+        try {
+            if (tag.hasKey("buyDisplayItem")) {
+                buyItemEntity = UUID.fromString(tag.getString("buyDisplayItem"));
+                Bukkit.getEntity(buyItemEntity).remove();
+            }
+            if (tag.hasKey("sellDisplayItem")) {
+                sellItemEntity = UUID.fromString(tag.getString("sellDisplayItem"));
+                Bukkit.getEntity(sellItemEntity).remove();
+            }
+        }catch (Exception ignored){}
     }
 
     public final ShopType getType() {
@@ -272,5 +279,18 @@ public class Shop {
 
     public Location getChestLocation() {
         return chest;
+    }
+
+    public void resetItemEntities(){
+        buyItemEntity = null;
+        sellItemEntity = null;
+    }
+
+    public UUID getBuyItemEntity() {
+        return buyItemEntity;
+    }
+
+    public UUID getSellItemEntity() {
+        return sellItemEntity;
     }
 }

--- a/src/com/kicasmads/cs/data/ShopDisplay.java
+++ b/src/com/kicasmads/cs/data/ShopDisplay.java
@@ -125,18 +125,22 @@ public class ShopDisplay {
 
     private void displayItem(Location location, ItemStack stack, boolean isBuy) {
         // Summon a persistent, non-pickup-able item
+        Item item = Utils.summonStaticItem(location, stack);
+        item.addScoreboardTag("chestShopDisplay");
+        item.addScoreboardTag("noKill");
+
         switch (shop.getType()) {
             case SELL:
-                sellItemEntity = Utils.summonStaticItem(location, stack).getUniqueId();
+                sellItemEntity = item.getUniqueId();
                 break;
             case BUY:
-                buyItemEntity = Utils.summonStaticItem(location, stack).getUniqueId();
+                buyItemEntity = item.getUniqueId();
                 break;
             case BARTER:
                 if (isBuy)
-                    buyItemEntity = Utils.summonStaticItem(location, stack).getUniqueId();
+                    buyItemEntity = item.getUniqueId();
                 else
-                    sellItemEntity = Utils.summonStaticItem(location, stack).getUniqueId();
+                    sellItemEntity = item.getUniqueId();
         }
     }
 
@@ -148,6 +152,8 @@ public class ShopDisplay {
         itemFrame.setVisible(false);
         itemFrame.setFixed(true);
 
+        itemFrame.addScoreboardTag("chestShopDisplay");
+        itemFrame.addScoreboardTag("noKill");
 
         switch (shop.getType()) {
             case SELL:
@@ -172,6 +178,8 @@ public class ShopDisplay {
         armorStand.setMarker(true); // Make it so that it can be clicked through
         armorStand.setSmall(smallStand);
         armorStand.getEquipment().setHelmet(item);
+        armorStand.addScoreboardTag("chestShopDisplay");
+        armorStand.addScoreboardTag("noKill");
         if (displayCase) {
             glassCaseAS = armorStand.getUniqueId();
         } else {
@@ -216,6 +224,8 @@ public class ShopDisplay {
             armorStand.setInvulnerable(true);
             armorStand.setMarker(true); // Make it so that it can be clicked through
             armorStand.getEquipment().setItemInMainHand(item);
+            armorStand.addScoreboardTag("chestShopDisplay");
+            armorStand.addScoreboardTag("noKill");
             if (shop.getType() == ShopType.SELL) {
                 sellItemEntity = armorStand.getUniqueId();
             } else {
@@ -240,6 +250,15 @@ public class ShopDisplay {
             if (glassCaseAS != null) {
                 Bukkit.getEntity(glassCaseAS).remove();
                 glassCaseAS = null;
+            }
+            if (shop.getSellItemEntity() != null || shop.getBuyItemEntity() != null) {
+                if (shop.getSellItemEntity() != null) {
+                    Bukkit.getEntity(shop.getSellItemEntity()).remove();
+                }
+                if (shop.getBuyItemEntity() != null) {
+                    Bukkit.getEntity(shop.getBuyItemEntity()).remove();
+                }
+                shop.resetItemEntities();
             }
         } catch (Exception ignored) {
         }


### PR DESCRIPTION
# Remove old display item and add scoreboard tags

## Removes old display item
Removes the pre-existing display item from 1.16.3 and before.  Attempts when the plugin is loaded and again whenever a shop display is cycled.

## Adds scoreboard tags
This adds the scoreboard tags `chestShopDisplay` and `noKill` for the ArmorStands, ItemFrames, and Items that are created with a shop.
This is useful for identifying which entities are part of the ChestShop's display.