### PR TITLE
Block Actions and Command Changes

### DIFF
--- a/src/com/kicasmads/cs/data/ShopDisplay.java
+++ b/src/com/kicasmads/cs/data/ShopDisplay.java
@@ -47,8 +47,6 @@ public class ShopDisplay {
         return Utils.formattedName(this.displayType);
     }
 
-    ;
-
     UUID uuidFromString(String s) {
         if (s.equals("none") || s.equals("null")) {
             return null;
@@ -79,7 +77,6 @@ public class ShopDisplay {
                 break;
         }
     }
-
 
     private void createDisplayItem() { // Create The ITEM_ONLY display (Item Entity)
         ItemStack buyItem = shop.getBuyItem();
@@ -287,6 +284,11 @@ public class ShopDisplay {
         }
         createShopDisplay();
         return displayType;
+    }
+
+    public void setDisplayType(DisplayType displayType){
+        this.displayType = displayType;
+        createShopDisplay();
     }
 
     public NBTTagCompound toNBT() {


### PR DESCRIPTION
# Block Actions and Command Changes

## Cancel Off Hand Action
Cancels the Off hand action when sneak right clicking on a sign to prevent a double chest display cycle

## Block Action Changes
When a block is placed above a chest, set the ShopDisplay to off
Cancel block place when block is placed by shift-clicking on a shop's signs

## Command Changes
`/shops` → Show Everyone's Shops
`/shops everyone` → Everyone's Shops
`/shops <playerName>` → Specific Person's Shops
`/shops me` → Personal Shops